### PR TITLE
optional auth for friends.get(long)

### DIFF
--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/AbstractVKontakteOperations.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/AbstractVKontakteOperations.java
@@ -60,6 +60,22 @@ class AbstractVKontakteOperations {
         }
     }
 
+    protected URI makeOptionalAuthOperationalURL(String method, Properties params, ApiVersion apiVersion) {
+        URIBuilder uri = URIBuilder.fromUri(VK_REST_URL + method);
+
+        if(accessToken != null) {
+            preProcessURI(uri);
+        }
+        // add api version
+        // TODO: I think finally we should migrate to latest api
+        uri.queryParam("v", apiVersion.toString());
+
+        for (Map.Entry<Object, Object> objectObjectEntry : params.entrySet()) {
+            uri.queryParam(objectObjectEntry.getKey().toString(), objectObjectEntry.getValue().toString());
+        }
+        return uri.build();
+    }
+
     protected URI makeOperationURL(String method, Properties params, ApiVersion apiVersion) {
         URIBuilder uri = URIBuilder.fromUri(VK_REST_URL + method);
 

--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/FriendsTemplate.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/FriendsTemplate.java
@@ -66,7 +66,9 @@ class FriendsTemplate extends AbstractVKontakteOperations implements IFriendsOpe
     }
 
     public VKArray<VKontakteProfile> get(Long userId, String fields, FriendsOrder order, NameCase nameCase, int count, int offset) {
-        requireAuthorization();
+        if(userId == null) {
+            requireAuthorization();
+        }
         Properties props = new Properties();
 
         if (userId != null) {
@@ -88,7 +90,12 @@ class FriendsTemplate extends AbstractVKontakteOperations implements IFriendsOpe
             props.put("name_case", nameCase.toString());
         }
 
-        URI uri = makeOperationURL("friends.get", props, ApiVersion.VERSION_5_27);
+        final URI uri;
+        if(userId == null) {
+            uri = makeOperationURL("friends.get", props, ApiVersion.VERSION_5_27);
+        } else {
+            uri = makeOptionalAuthOperationalURL("friends.get", props, ApiVersion.VERSION_5_27);
+        }
 
         VKGenericResponse response = restTemplate.getForObject(uri, VKGenericResponse.class);
         checkForError(response);

--- a/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/AbstractVKontakteApiTest.java
+++ b/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/AbstractVKontakteApiTest.java
@@ -29,18 +29,21 @@ import org.springframework.test.web.client.MockRestServiceServer;
 public class AbstractVKontakteApiTest {
 	protected VKontakteTemplate vkontakte;
 	protected VKontakteTemplate unauthorizedVKontakte;
+	//
 	protected MockRestServiceServer mockServer;
+	protected MockRestServiceServer unauthorizedMockServer;
 	protected HttpHeaders responseHeaders;
 
 	@Before
 	public void setup() {
-		vkontakte = new VKontakteTemplate("ACCESS_TOKEN", "CLIENT_SECRET");
-		mockServer = MockRestServiceServer.createServer(vkontakte.getRestTemplate());
 		responseHeaders = new HttpHeaders();
 		responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+		//
+		vkontakte = new VKontakteTemplate("ACCESS_TOKEN", "CLIENT_SECRET");
+		mockServer = MockRestServiceServer.createServer(vkontakte.getRestTemplate());
+		// unauthorizedVK can be used to access vk api public methods.
 		unauthorizedVKontakte = new VKontakteTemplate();
-		// create a mock server just to avoid hitting real vkontakte if something gets past the authorization check
-		MockRestServiceServer.createServer(unauthorizedVKontakte.getRestTemplate());
+		unauthorizedMockServer = MockRestServiceServer.createServer(unauthorizedVKontakte.getRestTemplate());
 	}
 
 	protected Resource jsonResource(String filename) {

--- a/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/FriendsTemplateTest.java
+++ b/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/FriendsTemplateTest.java
@@ -64,11 +64,11 @@ public class FriendsTemplateTest extends AbstractVKontakteApiTest {
 
     @Test
 	public void get_byUserId() throws ParseException {
-		mockServer.expect(requestTo("https://api.vk.com/method/friends.get?access_token=ACCESS_TOKEN&v=5.27&fields=first_name%2Clast_name%2Cphoto_50%2Cphoto_100%2Cphoto_200%2Ccontacts%2Cbdate%2Csex%2Cscreen_name&user_id=1"))
+		unauthorizedMockServer.expect(requestTo("https://api.vk.com/method/friends.get?v=5.27&fields=first_name%2Clast_name%2Cphoto_50%2Cphoto_100%2Cphoto_200%2Ccontacts%2Cbdate%2Csex%2Cscreen_name&user_id=1"))
 			.andExpect(method(GET))
 			.andRespond(withSuccess(jsonResource("list-of-friends-5_27"), APPLICATION_JSON));
 
-		VKArray<VKontakteProfile> friends = vkontakte.friendsOperations().get(1L);
+		VKArray<VKontakteProfile> friends = unauthorizedVKontakte.friendsOperations().get(1L);
         assertFriends(friends);
     }
 


### PR DESCRIPTION
as stated in issued #54 there are some methods in API which is 'public' (doesn't require authorization)

friends.get(with specified userId) is one of those

I fix throwing MissingAuthorizationException and added optional accessToken providing.