### PR TITLE
More public methods don't require authorization anymore

### DIFF
--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/IFriendsOperations.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/IFriendsOperations.java
@@ -48,41 +48,44 @@ public interface IFriendsOperations {
 
     /**
      * Retrieves a list of user friends for specified user unique identifier.
-     * @param userId user unique identifier for which to get friends.
+     * Does not require authorization if userId is not null
+     * @param userId user unique identifier for which to get friends (null for current user).
      * @return a list of user friends profiles.
 	 * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-	 * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
+	 * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token and userId is null.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     VKArray<VKontakteProfile> get(Long userId);
 
     /**
      * Retrieves a list of user friends for specified user unique identifier.
-     * @param userId user unique identifier for which to get friends.
+     * Does not require authorization if userId is not null
+     * @param userId user unique identifier for which to get friends (null for current user).
      * @param fields VKontakte fields to retrieve, comma-delimited.
      * @return a list of user friends profiles.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
+     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token and user id is null.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     VKArray<VKontakteProfile> get(Long userId, String fields);
 
     /**
      * Retrieves a list of user friends for specified user unique identifier.
-     * @param userId user unique identifier for which to get friends.
+     * Does not require authorization if userId is not null
+     * @param userId user unique identifier for which to get friends (null for current user).
      * @param fields VKontakte fields to retrieve, comma-delimited.
      * @param count Number(positive number) of friends to return. If you want to return all friends pass negative number.
      * @param offset Offset(positive number) needed to return a specific subset of friends.
      * @return a list of user friends profiles.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
+     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token and user id is null.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     VKArray<VKontakteProfile> get(Long userId, String fields, int count, int offset);
 
     /**
      * Retrieves a list of user friends for specified user unique identifier.
-     * @param userId user unique identifier for which to get friends.
+     * @param userId user unique identifier for which to get friends (null for current user).
      * @param fields VKontakte fields to retrieve, comma-delimited.
      * @param order sort order.
      * @param nameCase case for declension of user name and surname.
@@ -90,7 +93,7 @@ public interface IFriendsOperations {
      * @param offset Offset(positive number) needed to return a specific subset of friends.
      * @return a list of user friends profiles.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
+     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token and userId is null.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     VKArray<VKontakteProfile> get(Long userId, String fields, FriendsOrder order, NameCase nameCase, int count, int offset);

--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/IGroupsOperations.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/IGroupsOperations.java
@@ -23,7 +23,6 @@ public interface IGroupsOperations {
      * @param groupIds IDs or screen names of communities.
      * @return list of {@link Group} by IDs.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     List<Group> getByIds(Collection<String> groupIds);
@@ -34,7 +33,6 @@ public interface IGroupsOperations {
      * @param groupId ID or screen name of the community.
      * @return list of members.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     List<VKontakteProfile> getMembers(String groupId);
@@ -45,7 +43,6 @@ public interface IGroupsOperations {
      * @param fields VKontakte fields to retrieve, comma-delimited.
      * @return list of members.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     List<VKontakteProfile> getMembers(String groupId, String fields);
@@ -58,7 +55,6 @@ public interface IGroupsOperations {
      * @param offset Offset needed to return a specific subset of community members. (positive number)
      * @return list of members.
      * @throws org.springframework.social.ApiException if there is an error while communicating with VKontakte.
-     * @throws org.springframework.social.MissingAuthorizationException if VKontakteTemplate was not created with an access token.
      * @throws org.springframework.social.vkontakte.api.VKontakteErrorException if VKontakte returned error.
      */
     List<VKontakteProfile> getMembers(String groupId, String fields, int count, int offset);

--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/GroupsTemplate.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/GroupsTemplate.java
@@ -80,13 +80,11 @@ public class GroupsTemplate extends AbstractVKontakteOperations implements IGrou
 
     @Override
     public List<Group> getByIds(Collection<String> groupIds) {
-        requireAuthorization();
-
         String groupIdsCommaDelimited = StringUtils.collectionToCommaDelimitedString(groupIds);
         Properties props = new Properties();
         props.put("group_ids", groupIdsCommaDelimited);
 
-        URI uri = makeOperationURL("groups.getById", props, ApiVersion.VERSION_5_27);
+        URI uri = makeOptionalAuthOperationalURL("groups.getById", props, ApiVersion.VERSION_5_27);
         VKGenericResponse response = restTemplate.getForObject(uri, VKGenericResponse.class);
         checkForError(response);
 
@@ -105,8 +103,6 @@ public class GroupsTemplate extends AbstractVKontakteOperations implements IGrou
 
     @Override
     public List<VKontakteProfile> getMembers(String groupId, String fields, int count, int offset) {
-        requireAuthorization();
-
         Properties props = new Properties();
         props.put("group_id", groupId);
         props.put("fields", fields != null ? fields : IUsersOperations.DEFAULT_FIELDS);
@@ -119,7 +115,7 @@ public class GroupsTemplate extends AbstractVKontakteOperations implements IGrou
             props.put("offset", offset);
         }
 
-        URI uri = makeOperationURL("groups.getMembers", props, ApiVersion.VERSION_5_27);
+        URI uri = makeOptionalAuthOperationalURL("groups.getMembers", props, ApiVersion.VERSION_5_27);
         VKGenericResponse response = restTemplate.getForObject(uri, VKGenericResponse.class);
         checkForError(response);
 

--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/UtilsTemplate.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/UtilsTemplate.java
@@ -27,7 +27,7 @@ public class UtilsTemplate extends AbstractVKontakteOperations implements IUtils
     public VKObject resolveScreenName(String screenName) {
         Properties props = new Properties();
         props.put("screen_name", screenName);
-        URI uri = makeOperationURL("utils.resolveScreenName", props, ApiVersion.VERSION_5_27);
+        URI uri = makeOptionalAuthOperationalURL("utils.resolveScreenName", props, ApiVersion.VERSION_5_27);
         VKGenericResponse response = restTemplate.getForObject(uri, VKGenericResponse.class);
         return deserializeVK50Item(response, VKObject.class);
     }

--- a/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/WallTemplate.java
+++ b/spring-social-vkontakte/src/main/java/org/springframework/social/vkontakte/api/impl/WallTemplate.java
@@ -48,7 +48,9 @@ public class WallTemplate extends AbstractVKontakteOperations implements IWallOp
     }
 
     public List<Post> getPostsForUser(Long userId, int offset, int limit) {
-        requireAuthorization();
+        if(userId == null) {
+            requireAuthorization();
+        }
         Properties props = new Properties();
         if (offset >= 0) {
             props.put("offset", offset);
@@ -60,7 +62,7 @@ public class WallTemplate extends AbstractVKontakteOperations implements IWallOp
             props.put("owner_id", userId);
         }
         // http://vk.com/dev/wall.get
-        URI uri = makeOperationURL("wall.get", props, ApiVersion.VERSION_5_27);
+        URI uri = makeOptionalAuthOperationalURL("wall.get", props, ApiVersion.VERSION_5_27);
         VKGenericResponse response = restTemplate.getForObject(uri, VKGenericResponse.class);
         checkForError(response);
         return deserializeVK50ItemsResponse(response, Post.class).getItems();

--- a/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/UsersTemplateTest.java
+++ b/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/UsersTemplateTest.java
@@ -71,8 +71,12 @@ public class UsersTemplateTest extends AbstractVKontakteApiTest {
 
     @Test(expected = MissingAuthorizationException.class)
     public void getUsers_unauthorized() {
-        String[] userIds = {"1", "2"};
-        unauthorizedVKontakte.usersOperations().getUsers(Arrays.asList(userIds));
+        unauthorizedMockServer
+                .expect(requestTo("https://api.vk.com/method/users.get"))
+                .andExpect(method(POST)).andRespond(withSuccess(jsonResource("list-of-profiles-5_27"), APPLICATION_JSON));
+        String[] userIds = {"durov", "2183", "7748"};
+        final List<VKontakteProfile> profiles = unauthorizedVKontakte.usersOperations().getUsers(Arrays.asList(userIds));
+        assertProfiles(profiles);
     }
 
     @Test(expected = VKontakteErrorException.class)

--- a/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/UtilsTemplateTest.java
+++ b/spring-social-vkontakte/src/test/java/org/springframework/social/vkontakte/api/impl/UtilsTemplateTest.java
@@ -18,6 +18,7 @@ package org.springframework.social.vkontakte.api.impl;
 import org.junit.Test;
 import org.springframework.social.vkontakte.api.VKGenericResponse;
 import org.springframework.social.vkontakte.api.VKObject;
+import org.springframework.test.web.client.MockRestServiceServer;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.http.HttpMethod.GET;
@@ -34,12 +35,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 public class UtilsTemplateTest extends AbstractVKontakteApiTest {
     @Test
     public void resolveScreenName() {
-        mockServer.expect(requestTo("https://api.vk.com/method/utils.resolveScreenName?access_token=ACCESS_TOKEN&v=5.27&screen_name=durov"))
-                .andExpect(method(GET))
-                .andRespond(withSuccess(jsonResource("utils-resolve-screen-name-5.27"), APPLICATION_JSON));
-        VKObject vkObject = vkontakte.utilsOperations().resolveScreenName("durov");
-        assertEquals("user", vkObject.getType());
-        assertEquals(1, vkObject.getId());
+        resolveScreenNameImpl(this.mockServer, this.vkontakte, "https://api.vk.com/method/utils.resolveScreenName?access_token=ACCESS_TOKEN&v=5.27&screen_name=durov");
+    }
+
+    @Test
+    public void resolveScreenNameUnauthorized() {
+        resolveScreenNameImpl(unauthorizedMockServer, unauthorizedVKontakte, "https://api.vk.com/method/utils.resolveScreenName?v=5.27&screen_name=durov");
     }
 
     @Test
@@ -77,5 +78,14 @@ public class UtilsTemplateTest extends AbstractVKontakteApiTest {
                 "}";
         VKGenericResponse response = vkontakte.utilsOperations().execute(code);
         assertEquals(1, response.getResponse().get("post").get("copy_history").size());
+    }
+
+    private void resolveScreenNameImpl(MockRestServiceServer mockServer, VKontakteTemplate vkontakte, String expectedUri) {
+        mockServer.expect(requestTo(expectedUri))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(jsonResource("utils-resolve-screen-name-5.27"), APPLICATION_JSON));
+        VKObject vkObject = vkontakte.utilsOperations().resolveScreenName("durov");
+        assertEquals("user", vkObject.getType());
+        assertEquals(1, vkObject.getId());
     }
 }


### PR DESCRIPTION
I continue my crusade against public methods requiring for authorization:
Methods:
*groups.getByIds
*groups.getMemebers
*utils.resolveScreenName
*wall.get
don't require authorization anymore (still passing access_token if user is authorized)